### PR TITLE
Linux Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,14 @@ cmake_minimum_required (VERSION 3.8)
 
 project ("KVBench")
 
+# Optimization flags
+if(DEFINED ${CMAKE_HOST_WIN32})
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /O2")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2")
+else()
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+endif(DEFINED ${CMAKE_HOST_WIN32})
+
 # Include sub-projects.
 add_subdirectory ("KVBench")

--- a/KVBench/CMakeLists.txt
+++ b/KVBench/CMakeLists.txt
@@ -5,6 +5,6 @@ cmake_minimum_required (VERSION 3.8)
 
 
 # Add source to this project's executable.
-add_executable (KVBench "main.cpp" "Parsers/fastkv/fastkv.cpp" "Parsers/fastkv/fastkv.h" "Parsers/QuickKV/KVParser/quickkv.cpp" "Parsers/QuickKV/KVParser/quickkv.h")
+add_executable (KVBench "main.cpp" "Parsers/fastkv/fastkv.c" "Parsers/fastkv/fastkv.h" "Parsers/QuickKV/KVParser/quickkv.cpp" "Parsers/QuickKV/KVParser/quickkv.h")
 
 # TODO: Add tests and install targets if needed.

--- a/KVBench/main.cpp
+++ b/KVBench/main.cpp
@@ -11,8 +11,16 @@ char* ReadFile(const char* path, int& len)
 {
 
 	FILE* f;
-	fopen_s(&f, path, "rb");
-	fseek(f, 0, SEEK_END);
+
+        /* Use the "safe" crt functions for windows and normal ones for POSIX systems */
+#ifdef _WIN32 
+        fopen_s(&f, path, "rb");
+#else
+        f = fopen(path, "rb");
+        if(!f) abort();
+#endif 
+
+        fseek(f, 0, SEEK_END);
 	len = ftell(f);
 	rewind(f);
 	char* str = (char*)malloc(len + 1);

--- a/KVBench/main.cpp
+++ b/KVBench/main.cpp
@@ -3,7 +3,11 @@
 #include <time.h>
 
 //Parsers
+
+/* This is C source code */
+extern "C" {
 #include "Parsers/fastkv/fastkv.h"
+} 
 #include "Parsers/QuickKV/KVParser/quickkv.h"
 
 


### PR DESCRIPTION
This PR fixes a couple of issues with the benchmark on Linux.
1. fopen_s is only used on Windows now. On Linux normal fopen is used
2. Added some optimization flags
3. fastkv.c was referenced as fastkv.cpp in CMake, this has been fixed

This PR is meant to go with the other PR I opened on your QuickKV repo. Both are required for this to build properly on Linux.